### PR TITLE
Avoid complex invitation caching on the request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,11 @@ about future releases, check `milestones`_ and :doc:`/about/vision`.
 0.8 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Avoid complex invitation caching on the request
+
+WARNING: cached `invitation` is now set directly on the current `request` by
+         the `invitation_required` decorator. It won't create or update
+         `request.cache` attribute with `dict` like `{"invitation": "xxx"}`.
 
 
 0.7 (2018-10-15)

--- a/django_ticketoffice/decorators.py
+++ b/django_ticketoffice/decorators.py
@@ -25,11 +25,7 @@ forbidden_view = ForbiddenView.as_view(
 def guest_login(request, invitation):
     """Perform guest login in request."""
     # Cache the invitation instance in request.
-    try:
-        request.cache['invitation'] = invitation
-    except AttributeError:
-        setattr(request, 'cache', {'invitation': invitation})
-
+    request.invitation = invitation
     request.user = GuestUser(invitation=invitation, invitation_valid=True)
 
     try:
@@ -192,8 +188,8 @@ def stamp_invitation(view_func):
         response = view_func(request, *args, **kwargs)
         # Stamp ticket if available.
         try:
-            invitation = request.cache['invitation']
-        except (AttributeError, KeyError):
+            invitation = request.invitation
+        except AttributeError:
             raise  # Invitation not request! Missing @invitation_required?
         invitation.use()
         return response

--- a/django_ticketoffice/tests.py
+++ b/django_ticketoffice/tests.py
@@ -255,7 +255,6 @@ class InvitationRequiredTestCase(unittest.TestCase):
         invitation.uuid = fake_uuid
         self.assertTrue(invitation.is_valid())
         self.request.session = {'invitation': invitation}
-        self.request.cache = {}
         decorator = decorators.invitation_required(
             place=place,
             purpose=purpose)
@@ -274,7 +273,7 @@ class InvitationRequiredTestCase(unittest.TestCase):
         self.assertEqual(response, self.authorized_view.return_value)
         self.assertFalse(self.unauthorized_view.called)
         self.assertFalse(self.forbidden_view.called)
-        self.assertEqual(self.request.cache['invitation'], invitation)
+        self.assertEqual(self.request.invitation, invitation)
 
     def test_invalid_invitation_in_session(self):
         "invitation_required() with invalid guest session returns 403."

--- a/django_ticketoffice/views.py
+++ b/django_ticketoffice/views.py
@@ -17,8 +17,8 @@ class InvitationMixin(object):
             return self._invitation
         except AttributeError:
             try:
-                self._invitation = self.request.cache['invitation']
-            except (AttributeError, KeyError):
+                self._invitation = self.request.invitation
+            except AttributeError:
                 try:
                     ticket_uuid = UUID(self.request.session['invitation'])
                 except KeyError:


### PR DESCRIPTION
The dict overhead looks too complex for the needs. It can be conflicting with apps that use another caching mechanism per request :)